### PR TITLE
add derived graph

### DIFF
--- a/src/graph/__init__.py
+++ b/src/graph/__init__.py
@@ -1,4 +1,5 @@
 from .csv_graph import CSVGraph
+from .derived_graph import DerivedGraph
 from .graph import Graph
 from .graph_service import GraphService
 from .local_graph import LocalGraph
@@ -7,6 +8,7 @@ from .visualize import visualize
 
 __all__ = [
     "CSVGraph",
+    "DerivedGraph",
     "Graph",
     "GraphService",
     "LocalGraph",

--- a/src/graph/derived_graph.py
+++ b/src/graph/derived_graph.py
@@ -1,0 +1,50 @@
+from collections import defaultdict
+
+from .graph import Graph
+from .vertex import Vertex, VertexType
+
+
+class DerivedGraph(Graph):
+    def __init__(self, graph: Graph) -> None:
+        self.graph = graph
+
+    def add_vertex(self, vertex: Vertex) -> None:
+        raise ValueError("derived graphs are immutable")
+
+    @property
+    def vertices(self) -> set[Vertex]:
+        return self.graph.vertices
+
+    def add_directed_edge(self, src: Vertex, dest: Vertex, weight: float = 1.0) -> None:
+        raise ValueError("derived graphs are immutable")
+
+    def out_neighbors(self, vertex: Vertex) -> dict[Vertex, float]:
+        if vertex.type in (VertexType.IMAGE, VertexType.TAG):
+            return self.graph.out_neighbors(vertex)
+
+        out_neighbors = self.graph.out_neighbors(vertex)
+        if any(neighbor.type != VertexType.IMAGE for neighbor in out_neighbors):
+            raise ValueError("improperly formed graph")
+
+        second_neighbors = defaultdict(list)
+        for x1, w1 in out_neighbors(vertex):
+            for x2, w2 in self.graph.out_neighbors(x1).items():
+                second_neighbors[x2].append((w1, w2))
+
+        return {
+            x: sum(w1 * w2 for w1, w2 in weights) / sum(w2 for _, w2 in weights)
+            for x, weights in second_neighbors.items()
+        }
+
+    def in_neighbors(self, vertex: Vertex) -> dict[Vertex, float]:
+        in_neighbors = self.graph.in_neighbors(vertex)
+
+        second_neighbors = {
+            x2: self.out_neighbors(x2)[vertex]
+            for x1 in in_neighbors
+            if x1.type == VertexType.IMAGE
+            for x2 in self.graph.in_neighbors(x1)
+            if x2.type == VertexType.USER
+        }
+
+        return {**in_neighbors, **second_neighbors}

--- a/tests/graph/test_derived_graph.py
+++ b/tests/graph/test_derived_graph.py
@@ -1,0 +1,7 @@
+from .graph import DerivedGraph
+
+
+def test_derived_graph():
+    # TODO
+
+    assert False


### PR DESCRIPTION
We were discussing whether we should have direct user->tag edges or user->image and image->tag edges and infer the user->tag edges. Since the second is strictly stronger than the first, this PR introduces DerivedGraph which takes in a graph with user->image edges and acts as a view into this graph in which the user->image edges are gone and there are direct user->tag edges. See the overrides of out_neighbors and in_neighbors